### PR TITLE
Fix enabled support

### DIFF
--- a/toggle/src/main/java/com/github/angads25/toggle/LabeledSwitch.java
+++ b/toggle/src/main/java/com/github/angads25/toggle/LabeledSwitch.java
@@ -53,7 +53,6 @@ public class LabeledSwitch extends View {
     private int thumbRadii;
 
     private boolean isOn;
-    private boolean enabled;
 
     private Paint paint;
 
@@ -99,7 +98,6 @@ public class LabeledSwitch extends View {
         this.labelOn = "ON";
         this.labelOff = "OFF";
 
-        this.enabled = true;
         this.textSize = (int)(12f * getResources().getDisplayMetrics().scaledDensity);
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
@@ -156,8 +154,6 @@ public class LabeledSwitch extends View {
             } else if (attr == R.styleable.Toggle_android_textSize) {
                 int defaultTextSize = (int)(12f * getResources().getDisplayMetrics().scaledDensity);
                 textSize = tarr.getDimensionPixelSize(R.styleable.Toggle_android_textSize, defaultTextSize);
-            } else if(attr == R.styleable.Toggle_android_enabled) {
-                enabled = tarr.getBoolean(R.styleable.Toggle_android_enabled, false);
             }
         }
     }
@@ -506,10 +502,5 @@ public class LabeledSwitch extends View {
     public void setColorDisabled(int colorDisabled) {
         this.colorDisabled = colorDisabled;
         invalidate();
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return enabled;
     }
 }

--- a/toggle/src/main/res/values/attrs.xml
+++ b/toggle/src/main/res/values/attrs.xml
@@ -31,7 +31,5 @@
             format="boolean"/>
 
         <attr name="android:textSize"/>
-        
-        <attr name="android:enabled"/>
     </declare-styleable>
 </resources>


### PR DESCRIPTION
The old version was replicating `android:enabled` but that is already available at the `View` level.
When calling `label.setEnabled()` programmatically, the `enabled` flag would not be changed because it was not overriden.

Now everything works as expected, both from XML and code, using the internal enabled flag (at the View level, no need to create another).